### PR TITLE
Change a local copy of completion-at-point-functions, not the global one

### DIFF
--- a/ac-js2.el
+++ b/ac-js2.el
@@ -579,7 +579,7 @@ the function."
             map)
   (if (featurep 'auto-complete)
       (ac-js2-setup-auto-complete-mode))
-  (add-to-list 'completion-at-point-functions 'ac-js2-completion-function)
+  (add-hook 'completion-at-point-functions 'ac-js2-completion-function nil t)
   (ac-js2-skewer-eval-wrapper (buffer-string))
   (add-hook 'before-save-hook 'ac-js2-save nil t)
   (add-hook 'skewer-js-hook 'ac-js2-on-skewer-load))


### PR DESCRIPTION
As with dgutov/robe#4, ac-js2 currently clobbers the global `completion-at-point-functions` list, which messes up completion in the minibuffer.

This fix is analogous to that applied by @dgutov in https://github.com/dgutov/robe/commit/28965cc552b01b21f9028118d1fe5143d3c04a5e

Cheers,

-Steve
